### PR TITLE
Inherit leaf update rules to children (clientCanUpdate)

### DIFF
--- a/src/api/server/incoming.js
+++ b/src/api/server/incoming.js
@@ -56,7 +56,7 @@ const setLeaves = (branch, socket, leaves) => {
 
       const setPath = path(branch, id)
       const rule = branch.clientCanUpdate.find(
-        rule => rule.path.length === setPath.length && rule.path.every(
+        rule => rule.path.length <= setPath.length && rule.path.every(
           (key, i) => key === '*' || key === setPath[i]
         )
       )


### PR DESCRIPTION
This PR changes the comparison operator when checking leaf updates against `clientCanUpdate`.

Essentially this allows for summarization / parent inheritance in `clientCanUpdate`:

**Before**

```js
[request] Set [ 'parent', 'child1', 'prop1' ] to 'new value'

with:
clientCanUpdate = [ { path: [ 'parent' ] } ]           // Rejected
clientCanUpdate = [ { path: [ 'parent', '*' ] } ]      // Rejected
clientCanUpdate = [ { path: [ 'parent', '*' , '*'] } ] // Accepted

// Observation: '*' is required for each sub layer, because the rule path length must match the request path length
```

**With PR**

```js
[request] Set [ 'parent', 'child1', 'prop1' ] to 'new value'

with:
clientCanUpdate = [ { path: [ 'parent' ] } ]           // Accepted

// Observation: '*' is no longer required for sub-properties.
// The first rule now declares that every property below 'parent' is updatable.
```